### PR TITLE
More precise search for pure damage VS DoT

### DIFF
--- a/IAGrim/UI/Filters/Damage.Designer.cs
+++ b/IAGrim/UI/Filters/Damage.Designer.cs
@@ -32,7 +32,7 @@
             this.dmgFire = new FirefoxCheckBox();
             this.dmgAether = new FirefoxCheckBox();
             this.dmgCold = new FirefoxCheckBox();
-            this.dmgPoison = new FirefoxCheckBox();
+            this.dmgAcid = new FirefoxCheckBox();
             this.dmgLightning = new FirefoxCheckBox();
             this.dmgVitality = new FirefoxCheckBox();
             this.dmgChaos = new FirefoxCheckBox();
@@ -50,7 +50,7 @@
             this.damagePanel.Controls.Add(this.dmgFire);
             this.damagePanel.Controls.Add(this.dmgAether);
             this.damagePanel.Controls.Add(this.dmgCold);
-            this.damagePanel.Controls.Add(this.dmgPoison);
+            this.damagePanel.Controls.Add(this.dmgAcid);
             this.damagePanel.Controls.Add(this.dmgLightning);
             this.damagePanel.Controls.Add(this.dmgVitality);
             this.damagePanel.Controls.Add(this.dmgChaos);
@@ -187,20 +187,20 @@
             this.dmgCold.Tag = "iatag_ui_cold";
             this.dmgCold.Text = "Cold";
             // 
-            // dmgPoison
+            // dmgAcid
             // 
-            this.dmgPoison.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.dmgAcid.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.dmgPoison.Bold = false;
-            this.dmgPoison.EnabledCalc = true;
-            this.dmgPoison.Font = new System.Drawing.Font("Segoe UI", 10F);
-            this.dmgPoison.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(66)))), ((int)(((byte)(78)))), ((int)(((byte)(90)))));
-            this.dmgPoison.Location = new System.Drawing.Point(3, 302);
-            this.dmgPoison.Name = "dmgPoison";
-            this.dmgPoison.Size = new System.Drawing.Size(275, 27);
-            this.dmgPoison.TabIndex = 32;
-            this.dmgPoison.Tag = "iatag_ui_poison";
-            this.dmgPoison.Text = "Poison";
+            this.dmgAcid.Bold = false;
+            this.dmgAcid.EnabledCalc = true;
+            this.dmgAcid.Font = new System.Drawing.Font("Segoe UI", 10F);
+            this.dmgAcid.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(66)))), ((int)(((byte)(78)))), ((int)(((byte)(90)))));
+            this.dmgAcid.Location = new System.Drawing.Point(3, 302);
+            this.dmgAcid.Name = "dmgAcid";
+            this.dmgAcid.Size = new System.Drawing.Size(275, 27);
+            this.dmgAcid.TabIndex = 32;
+            this.dmgAcid.Tag = "iatag_ui_acid";
+            this.dmgAcid.Text = "Acid";
             // 
             // dmgLightning
             // 
@@ -270,7 +270,7 @@
         private FirefoxCheckBox dmgFire;
         private FirefoxCheckBox dmgAether;
         private FirefoxCheckBox dmgCold;
-        private FirefoxCheckBox dmgPoison;
+        private FirefoxCheckBox dmgAcid;
         private FirefoxCheckBox dmgLightning;
         private FirefoxCheckBox dmgVitality;
         private FirefoxCheckBox dmgChaos;

--- a/IAGrim/UI/Filters/Damage.cs
+++ b/IAGrim/UI/Filters/Damage.cs
@@ -42,30 +42,17 @@ namespace IAGrim.UI.Filters {
                 if (dmgAcid.Checked)
                     dmgTypes.Add("Poison");
 
-                if (dmgElemental.Checked)
+                if (dmgElemental.Checked || dmgTypes.Contains("Fire") || dmgTypes.Contains("Cold") || dmgTypes.Contains("Lightning"))
                     dmgTypes.Add("Elemental");
 
                 if (totalDamage.Checked)
                     filters.Add(new[] {"offensiveTotalDamageModifier"});
 
-                foreach (var damageType in dmgTypes) {
-                    var isElemental = damageType.Equals("Fire") ||
-                                      damageType.Equals("Cold") ||
-                                      damageType.Equals("Lightning");
-
-                    if (isElemental)
-                        filters.Add(new[] {
-                            $"offensive{damageType}",
-                            $"offensive{damageType}Modifier",
-                            "offensiveElemental",
-                            "offensiveElementalModifier"
-                        });
-                    else
-                        filters.Add(new[] {
-                            $"offensive{damageType}",
-                            $"offensive{damageType}Modifier"
-                        });
-                }
+                foreach (var damageType in dmgTypes)
+                    filters.Add(new[] {
+                        $"offensive{damageType}",
+                        $"offensive{damageType}Modifier"
+                    });
 
                 return filters;
             }

--- a/IAGrim/UI/Filters/Damage.cs
+++ b/IAGrim/UI/Filters/Damage.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using System.Windows.Forms;
 
 namespace IAGrim.UI.Filters {
@@ -22,71 +15,56 @@ namespace IAGrim.UI.Filters {
 
                 // +Damage
                 var dmgTypes = new List<string>();
-                if (dmgPhysical.Checked) {
+                if (dmgPhysical.Checked)
                     dmgTypes.Add("Physical");
-                }
 
-                if (dmgPiercing.Checked) {
+                if (dmgPiercing.Checked)
                     dmgTypes.Add("Pierce");
-                }
 
-                if (dmgFire.Checked) {
+                if (dmgFire.Checked)
                     dmgTypes.Add("Fire");
-                }
 
-                if (dmgCold.Checked) {
+                if (dmgCold.Checked)
                     dmgTypes.Add("Cold");
-                }
 
-                if (dmgLightning.Checked) {
+                if (dmgLightning.Checked)
                     dmgTypes.Add("Lightning");
-                }
 
-                if (dmgAether.Checked) {
+                if (dmgAether.Checked)
                     dmgTypes.Add("Aether");
-                }
 
-                if (dmgVitality.Checked) {
+                if (dmgVitality.Checked)
                     dmgTypes.Add("Life");
-                }
 
-                if (dmgChaos.Checked) {
+                if (dmgChaos.Checked)
                     dmgTypes.Add("Chaos");
-                }
 
-                if (dmgAcid.Checked) {
+                if (dmgAcid.Checked)
                     dmgTypes.Add("Poison");
-                }
 
-                if (dmgElemental.Checked) {
+                if (dmgElemental.Checked)
                     dmgTypes.Add("Elemental");
-                }
 
-                if (totalDamage.Checked) {
-                    filters.Add(new[] { "offensiveTotalDamageModifier" });
-                }
-
+                if (totalDamage.Checked)
+                    filters.Add(new[] {"offensiveTotalDamageModifier"});
 
                 foreach (var damageType in dmgTypes) {
-                    var isElemental = damageType.Equals("Fire") || damageType.Equals("Cold") ||
+                    var isElemental = damageType.Equals("Fire") ||
+                                      damageType.Equals("Cold") ||
                                       damageType.Equals("Lightning");
 
-                    if (isElemental) {
-                        filters.Add(new[]
-                        {
+                    if (isElemental)
+                        filters.Add(new[] {
                             $"offensive{damageType}",
                             $"offensive{damageType}Modifier",
                             "offensiveElemental",
                             "offensiveElementalModifier"
                         });
-                    }
-                    else {
-                        filters.Add(new[]
-                        {
+                    else
+                        filters.Add(new[] {
                             $"offensive{damageType}",
                             $"offensive{damageType}Modifier"
                         });
-                    }
                 }
 
                 return filters;

--- a/IAGrim/UI/Filters/Damage.cs
+++ b/IAGrim/UI/Filters/Damage.cs
@@ -54,7 +54,7 @@ namespace IAGrim.UI.Filters {
                     dmgTypes.Add("Chaos");
                 }
 
-                if (dmgPoison.Checked) {
+                if (dmgAcid.Checked) {
                     dmgTypes.Add("Poison");
                 }
 
@@ -77,18 +77,14 @@ namespace IAGrim.UI.Filters {
                             $"offensive{damageType}",
                             $"offensive{damageType}Modifier",
                             "offensiveElemental",
-                            "offensiveElementalModifier",
-                            $"offensiveSlow{damageType}",
-                            $"offensiveSlow{damageType}Modifier"
+                            "offensiveElementalModifier"
                         });
                     }
                     else {
                         filters.Add(new[]
                         {
                             $"offensive{damageType}",
-                            $"offensive{damageType}Modifier",
-                            $"offensiveSlow{damageType}",
-                            $"offensiveSlow{damageType}Modifier"
+                            $"offensive{damageType}Modifier"
                         });
                     }
                 }

--- a/IAGrim/UI/Filters/DamageOverTime.Designer.cs
+++ b/IAGrim/UI/Filters/DamageOverTime.Designer.cs
@@ -24,7 +24,8 @@
         /// </summary>
         private void InitializeComponent() {
             this.dotPanel = new IAGrim.Theme.CollapseablePanelBox();
-            this.cbLifeLeech = new FirefoxCheckBox();
+            this.dmgPoison = new FirefoxCheckBox();
+            this.dmgLifeLeech = new FirefoxCheckBox();
             this.dmgVitalityDecay = new FirefoxCheckBox();
             this.dmgFrost = new FirefoxCheckBox();
             this.dmgTrauma = new FirefoxCheckBox();
@@ -36,7 +37,9 @@
             // 
             // dotPanel
             // 
-            this.dotPanel.Controls.Add(this.cbLifeLeech);
+            this.dotPanel.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.dotPanel.Controls.Add(this.dmgPoison);
+            this.dotPanel.Controls.Add(this.dmgLifeLeech);
             this.dotPanel.Controls.Add(this.dmgVitalityDecay);
             this.dotPanel.Controls.Add(this.dmgFrost);
             this.dotPanel.Controls.Add(this.dmgTrauma);
@@ -44,30 +47,49 @@
             this.dotPanel.Controls.Add(this.dmgElectrocute);
             this.dotPanel.Controls.Add(this.dmgBleeding);
             this.dotPanel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold);
+            this.dotPanel.ForeColor = System.Drawing.Color.Black;
+            this.dotPanel.HeaderColor = System.Drawing.Color.FromArgb(((int)(((byte)(231)))), ((int)(((byte)(231)))), ((int)(((byte)(231)))));
             this.dotPanel.HeaderHeight = 29;
             this.dotPanel.Location = new System.Drawing.Point(0, 0);
             this.dotPanel.Name = "dotPanel";
             this.dotPanel.NoRounding = false;
-            this.dotPanel.Size = new System.Drawing.Size(285, 277);
+            this.dotPanel.Size = new System.Drawing.Size(285, 296);
             this.dotPanel.TabIndex = 42;
             this.dotPanel.Tag = "iatag_ui_dot";
             this.dotPanel.Text = "Damage over Time";
             this.dotPanel.TextLocation = "8; 5";
             // 
-            // cbLifeLeech
+            // dmgPoison
             // 
-            this.cbLifeLeech.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.dmgPoison.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.cbLifeLeech.Bold = false;
-            this.cbLifeLeech.EnabledCalc = true;
-            this.cbLifeLeech.Font = new System.Drawing.Font("Segoe UI", 10F);
-            this.cbLifeLeech.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(66)))), ((int)(((byte)(78)))), ((int)(((byte)(90)))));
-            this.cbLifeLeech.Location = new System.Drawing.Point(3, 231);
-            this.cbLifeLeech.Name = "cbLifeLeech";
-            this.cbLifeLeech.Size = new System.Drawing.Size(267, 27);
-            this.cbLifeLeech.TabIndex = 6;
-            this.cbLifeLeech.Tag = "iatag_ui_lifeleech";
-            this.cbLifeLeech.Text = "Life Leech";
+            this.dmgPoison.Bold = false;
+            this.dmgPoison.EnabledCalc = true;
+            this.dmgPoison.Font = new System.Drawing.Font("Segoe UI", 10F);
+            this.dmgPoison.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(66)))), ((int)(((byte)(78)))), ((int)(((byte)(90)))));
+            this.dmgPoison.IsDarkMode = false;
+            this.dmgPoison.Location = new System.Drawing.Point(3, 264);
+            this.dmgPoison.Name = "dmgPoison";
+            this.dmgPoison.Size = new System.Drawing.Size(267, 27);
+            this.dmgPoison.TabIndex = 7;
+            this.dmgPoison.Tag = "iatag_ui_poison";
+            this.dmgPoison.Text = "Poison";
+            // 
+            // dmgLifeLeech
+            // 
+            this.dmgLifeLeech.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.dmgLifeLeech.Bold = false;
+            this.dmgLifeLeech.EnabledCalc = true;
+            this.dmgLifeLeech.Font = new System.Drawing.Font("Segoe UI", 10F);
+            this.dmgLifeLeech.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(66)))), ((int)(((byte)(78)))), ((int)(((byte)(90)))));
+            this.dmgLifeLeech.IsDarkMode = false;
+            this.dmgLifeLeech.Location = new System.Drawing.Point(3, 231);
+            this.dmgLifeLeech.Name = "dmgLifeLeech";
+            this.dmgLifeLeech.Size = new System.Drawing.Size(267, 27);
+            this.dmgLifeLeech.TabIndex = 6;
+            this.dmgLifeLeech.Tag = "iatag_ui_lifeleech";
+            this.dmgLifeLeech.Text = "Life Leech";
             // 
             // dmgVitalityDecay
             // 
@@ -77,6 +99,7 @@
             this.dmgVitalityDecay.EnabledCalc = true;
             this.dmgVitalityDecay.Font = new System.Drawing.Font("Segoe UI", 10F);
             this.dmgVitalityDecay.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(66)))), ((int)(((byte)(78)))), ((int)(((byte)(90)))));
+            this.dmgVitalityDecay.IsDarkMode = false;
             this.dmgVitalityDecay.Location = new System.Drawing.Point(3, 198);
             this.dmgVitalityDecay.Name = "dmgVitalityDecay";
             this.dmgVitalityDecay.Size = new System.Drawing.Size(267, 27);
@@ -92,6 +115,7 @@
             this.dmgFrost.EnabledCalc = true;
             this.dmgFrost.Font = new System.Drawing.Font("Segoe UI", 10F);
             this.dmgFrost.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(66)))), ((int)(((byte)(78)))), ((int)(((byte)(90)))));
+            this.dmgFrost.IsDarkMode = false;
             this.dmgFrost.Location = new System.Drawing.Point(3, 132);
             this.dmgFrost.Name = "dmgFrost";
             this.dmgFrost.Size = new System.Drawing.Size(267, 27);
@@ -107,6 +131,7 @@
             this.dmgTrauma.EnabledCalc = true;
             this.dmgTrauma.Font = new System.Drawing.Font("Segoe UI", 10F);
             this.dmgTrauma.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(66)))), ((int)(((byte)(78)))), ((int)(((byte)(90)))));
+            this.dmgTrauma.IsDarkMode = false;
             this.dmgTrauma.Location = new System.Drawing.Point(3, 66);
             this.dmgTrauma.Name = "dmgTrauma";
             this.dmgTrauma.Size = new System.Drawing.Size(267, 27);
@@ -122,6 +147,7 @@
             this.dmgBurn.EnabledCalc = true;
             this.dmgBurn.Font = new System.Drawing.Font("Segoe UI", 10F);
             this.dmgBurn.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(66)))), ((int)(((byte)(78)))), ((int)(((byte)(90)))));
+            this.dmgBurn.IsDarkMode = false;
             this.dmgBurn.Location = new System.Drawing.Point(3, 99);
             this.dmgBurn.Name = "dmgBurn";
             this.dmgBurn.Size = new System.Drawing.Size(267, 27);
@@ -137,6 +163,7 @@
             this.dmgElectrocute.EnabledCalc = true;
             this.dmgElectrocute.Font = new System.Drawing.Font("Segoe UI", 10F);
             this.dmgElectrocute.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(66)))), ((int)(((byte)(78)))), ((int)(((byte)(90)))));
+            this.dmgElectrocute.IsDarkMode = false;
             this.dmgElectrocute.Location = new System.Drawing.Point(3, 165);
             this.dmgElectrocute.Name = "dmgElectrocute";
             this.dmgElectrocute.Size = new System.Drawing.Size(267, 27);
@@ -152,6 +179,7 @@
             this.dmgBleeding.EnabledCalc = true;
             this.dmgBleeding.Font = new System.Drawing.Font("Segoe UI", 10F);
             this.dmgBleeding.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(66)))), ((int)(((byte)(78)))), ((int)(((byte)(90)))));
+            this.dmgBleeding.IsDarkMode = false;
             this.dmgBleeding.Location = new System.Drawing.Point(3, 33);
             this.dmgBleeding.Name = "dmgBleeding";
             this.dmgBleeding.Size = new System.Drawing.Size(267, 27);
@@ -165,7 +193,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.dotPanel);
             this.Name = "DamageOverTimeFilter";
-            this.Size = new System.Drawing.Size(285, 277);
+            this.Size = new System.Drawing.Size(285, 299);
             this.dotPanel.ResumeLayout(false);
             this.ResumeLayout(false);
 
@@ -174,12 +202,13 @@
         #endregion
 
         private Theme.CollapseablePanelBox dotPanel;
-        private FirefoxCheckBox cbLifeLeech;
+        private FirefoxCheckBox dmgLifeLeech;
         private FirefoxCheckBox dmgVitalityDecay;
         private FirefoxCheckBox dmgFrost;
         private FirefoxCheckBox dmgTrauma;
         private FirefoxCheckBox dmgBurn;
         private FirefoxCheckBox dmgElectrocute;
         private FirefoxCheckBox dmgBleeding;
+        private FirefoxCheckBox dmgPoison;
     }
 }

--- a/IAGrim/UI/Filters/DamageOverTime.cs
+++ b/IAGrim/UI/Filters/DamageOverTime.cs
@@ -1,18 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace IAGrim.UI.Filters {
     partial class DamageOverTimeFilter : UserControl {
         public DamageOverTimeFilter() {
             InitializeComponent();
-            this.Load += DamageOverTimeFilter_Load;
+            Load += DamageOverTimeFilter_Load;
         }
 
         public void DamageOverTimeFilter_Load(object sender, EventArgs e) {
@@ -22,38 +16,30 @@ namespace IAGrim.UI.Filters {
         public List<string[]> Filters {
             get {
                 var dotTypes = new List<string>();
-                if (dmgBleeding.Checked) {
+                if (dmgBleeding.Checked)
                     dotTypes.Add("Bleeding");
-                }
 
-                if (dmgTrauma.Checked) {
+                if (dmgTrauma.Checked)
                     dotTypes.Add("Physical");
-                }
 
-                if (dmgBurn.Checked) {
+                if (dmgBurn.Checked)
                     dotTypes.Add("Fire");
-                }
 
-                if (dmgElectrocute.Checked) {
+                if (dmgElectrocute.Checked)
                     dotTypes.Add("Lightning");
-                }
 
-                if (dmgVitalityDecay.Checked) {
+                if (dmgVitalityDecay.Checked)
                     dotTypes.Add("Life");
-                }
 
-                if (dmgFrost.Checked) {
+                if (dmgFrost.Checked)
                     dotTypes.Add("Cold");
-                }
 
-                if (dmgPoison.Checked) {
+                if (dmgPoison.Checked)
                     dotTypes.Add("Poison");
-                }
 
                 var filters = new List<string[]>();
-                foreach (var dot in dotTypes) {
-                    filters.Add(new[]
-                    {
+                foreach (var dot in dotTypes)
+                    filters.Add(new[] {
                         $"offensiveSlow{dot}",
                         $"offensiveSlow{dot}Modifier",
                         $"offensiveSlow{dot}ModifierChance",
@@ -63,11 +49,9 @@ namespace IAGrim.UI.Filters {
                         $"retaliationSlow{dot}Duration",
                         $"retaliationSlow{dot}DurationMin"
                     });
-                }
 
-                if (dmgLifeLeech.Checked) {
-                    filters.Add(new[] { "offensiveLifeLeechMin", "offensiveSlowLifeLeachMin" });
-                }
+                if (dmgLifeLeech.Checked)
+                    filters.Add(new[] {"offensiveLifeLeechMin", "offensiveSlowLifeLeachMin"});
 
                 return filters;
             }

--- a/IAGrim/UI/Filters/DamageOverTime.cs
+++ b/IAGrim/UI/Filters/DamageOverTime.cs
@@ -46,6 +46,10 @@ namespace IAGrim.UI.Filters {
                     dotTypes.Add("Cold");
                 }
 
+                if (dmgPoison.Checked) {
+                    dotTypes.Add("Poison");
+                }
+
                 var filters = new List<string[]>();
                 foreach (var dot in dotTypes) {
                     filters.Add(new[]
@@ -61,7 +65,7 @@ namespace IAGrim.UI.Filters {
                     });
                 }
 
-                if (cbLifeLeech.Checked) {
+                if (dmgLifeLeech.Checked) {
                     filters.Add(new[] { "offensiveLifeLeechMin", "offensiveSlowLifeLeachMin" });
                 }
 

--- a/StatTranslator/EnglishLanguage.cs
+++ b/StatTranslator/EnglishLanguage.cs
@@ -6,15 +6,13 @@ namespace StatTranslator {
         public bool WarnIfMissing => true;
 
         public EnglishLanguage(Dictionary<string, string> existingTags) {
-            foreach (string tag in existingTags.Keys) {
+            foreach (var tag in existingTags.Keys)
                 SetTagIfMissing(tag, existingTags[tag]);
-            }
         }
 
         public void SetTagIfMissing(string tag, string value) {
-            if (!_stats.ContainsKey(tag)) {
+            if (!_stats.ContainsKey(tag))
                 _stats[tag] = value;
-            }
         }
 
         public string Export() {
@@ -699,8 +697,8 @@ namespace StatTranslator {
         }
 
         public string GetTag(string tag) {
-            return _stats.ContainsKey(tag) 
-                ? _stats[tag] 
+            return _stats.ContainsKey(tag)
+                ? _stats[tag]
                 : string.Empty;
         }
 

--- a/StatTranslator/EnglishLanguage.cs
+++ b/StatTranslator/EnglishLanguage.cs
@@ -430,6 +430,7 @@ namespace StatTranslator {
             {"iatag_ui_fire", "Fire"},
             {"iatag_ui_aether", "Aether"},
             {"iatag_ui_cold", "Cold"},
+            {"iatag_ui_acid", "Acid"},
             {"iatag_ui_poison", "Poison"},
             {"iatag_ui_lightning", "Lightning"},
             {"iatag_ui_vitality", "Vitality"},


### PR DESCRIPTION
Some items, such as Vilescorn Legplates, have base type damage modifier, but not DoT. And some items, such as Eye of the Beholder, have DoT damage, but not its base counterpart.