### PR TITLE
Defer creation of indexes for item tables until after all of the records have been imported

### DIFF
--- a/IAGrim/Database/Interfaces/IDatabaseItemDao.cs
+++ b/IAGrim/Database/Interfaces/IDatabaseItemDao.cs
@@ -7,6 +7,7 @@ namespace IAGrim.Database.Interfaces {
     public interface IDatabaseItemDao : IBaseDao<DatabaseItem> {
         Dictionary<string, string> GetTagDictionary();
         void Save(List<DatabaseItem> items, ProgressTracker progressTracker);
+        void CreateItemIndexes(ProgressTracker progressTracker);
         DatabaseItem FindByRecord(string record);
         IList<string> ListAllRecords();
 

--- a/IAGrim/Database/Synchronizer/DatabaseItemRepo.cs
+++ b/IAGrim/Database/Synchronizer/DatabaseItemRepo.cs
@@ -111,6 +111,14 @@ namespace IAGrim.Database.Synchronizer {
             );
         }
 
+        public void CreateItemIndexes(ProgressTracker progressTracker) {
+            ThreadExecuter.Execute(
+                () => _repo.CreateItemIndexes(progressTracker),
+                ThreadExecuter.ThreadTimeout * 2,
+                true
+            );
+        }
+
 
         public void Clean() {
             ThreadExecuter.Execute(

--- a/IAGrim/Parsers/GameDataParsing/Service/ParsingService.cs
+++ b/IAGrim/Parsers/GameDataParsing/Service/ParsingService.cs
@@ -119,6 +119,7 @@ namespace IAGrim.Parsers.GameDataParsing.Service {
             actions.Add(() => parser.MapItemNames(new WinformsProgressBar(form.MappingItemNames).Tracker));
             actions.Add(() => parser.RenamePetStats(new WinformsProgressBar(form.MappingPetStats).Tracker));
             actions.Add(() => _databaseItemDao.Save(parser.Items, new WinformsProgressBar(form.SavingItems).Tracker));
+            actions.Add(() => _databaseItemDao.CreateItemIndexes(new WinformsProgressBar(form.IndexingItems).Tracker));
 
             // TODO: This depends on the DB item name.. which is in english, not localized
             actions.Add(() => {

--- a/IAGrim/Parsers/GameDataParsing/UI/ParsingDatabaseProgressView.Designer.cs
+++ b/IAGrim/Parsers/GameDataParsing/UI/ParsingDatabaseProgressView.Designer.cs
@@ -26,6 +26,8 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ParsingDatabaseProgressView));
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.progressIndexItems = new System.Windows.Forms.ProgressBar();
+            this.label11 = new System.Windows.Forms.Label();
             this.progressSavingSpecialStats = new System.Windows.Forms.ProgressBar();
             this.label10 = new System.Windows.Forms.Label();
             this.progressSkillCorrectnessCheck = new System.Windows.Forms.ProgressBar();
@@ -55,9 +57,11 @@
             this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox1.Controls.Add(this.tableLayoutPanel2);
-            this.groupBox1.Location = new System.Drawing.Point(13, 12);
+            this.groupBox1.Location = new System.Drawing.Point(17, 15);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(399, 222);
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox1.Size = new System.Drawing.Size(532, 308);
             this.groupBox1.TabIndex = 2;
             this.groupBox1.TabStop = false;
             this.groupBox1.Tag = "iatag_ui_parsing_gd_resources";
@@ -72,16 +76,18 @@
             this.tableLayoutPanel2.ColumnCount = 2;
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel2.Controls.Add(this.progressSavingSpecialStats, 1, 7);
-            this.tableLayoutPanel2.Controls.Add(this.label10, 0, 7);
-            this.tableLayoutPanel2.Controls.Add(this.progressSkillCorrectnessCheck, 1, 9);
-            this.tableLayoutPanel2.Controls.Add(this.progressGeneratingSkills, 1, 8);
-            this.tableLayoutPanel2.Controls.Add(this.label9, 0, 9);
+            this.tableLayoutPanel2.Controls.Add(this.progressIndexItems, 1, 6);
+            this.tableLayoutPanel2.Controls.Add(this.label11, 0, 6);
+            this.tableLayoutPanel2.Controls.Add(this.progressSavingSpecialStats, 1, 8);
+            this.tableLayoutPanel2.Controls.Add(this.label10, 0, 8);
+            this.tableLayoutPanel2.Controls.Add(this.progressSkillCorrectnessCheck, 1, 10);
+            this.tableLayoutPanel2.Controls.Add(this.progressGeneratingSkills, 1, 9);
+            this.tableLayoutPanel2.Controls.Add(this.label9, 0, 10);
             this.tableLayoutPanel2.Controls.Add(this.label5, 0, 3);
-            this.tableLayoutPanel2.Controls.Add(this.label8, 0, 8);
+            this.tableLayoutPanel2.Controls.Add(this.label8, 0, 9);
             this.tableLayoutPanel2.Controls.Add(this.progressMappingPetStats, 1, 4);
             this.tableLayoutPanel2.Controls.Add(this.label7, 0, 5);
-            this.tableLayoutPanel2.Controls.Add(this.progressGeneratingSpecialStats, 1, 6);
+            this.tableLayoutPanel2.Controls.Add(this.progressGeneratingSpecialStats, 1, 7);
             this.tableLayoutPanel2.Controls.Add(this.progressMappingItemNames, 1, 3);
             this.tableLayoutPanel2.Controls.Add(this.label6, 0, 4);
             this.tableLayoutPanel2.Controls.Add(this.progressSaveItems, 1, 5);
@@ -91,41 +97,67 @@
             this.tableLayoutPanel2.Controls.Add(this.label2, 0, 1);
             this.tableLayoutPanel2.Controls.Add(this.progressLoadingTags, 1, 0);
             this.tableLayoutPanel2.Controls.Add(this.label3, 0, 2);
-            this.tableLayoutPanel2.Controls.Add(this.label4, 0, 6);
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(6, 19);
+            this.tableLayoutPanel2.Controls.Add(this.label4, 0, 7);
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(8, 23);
+            this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 10;
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(387, 197);
+            this.tableLayoutPanel2.RowCount = 11;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(516, 277);
             this.tableLayoutPanel2.TabIndex = 18;
             this.tableLayoutPanel2.UseWaitCursor = true;
+            // 
+            // progressIndexItems
+            // 
+            this.progressIndexItems.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.progressIndexItems.Location = new System.Drawing.Point(262, 154);
+            this.progressIndexItems.Margin = new System.Windows.Forms.Padding(4);
+            this.progressIndexItems.Name = "progressIndexItems";
+            this.progressIndexItems.Size = new System.Drawing.Size(250, 17);
+            this.progressIndexItems.TabIndex = 22;
+            this.progressIndexItems.UseWaitCursor = true;
+            // 
+            // label11
+            // 
+            this.label11.AutoSize = true;
+            this.label11.Location = new System.Drawing.Point(4, 150);
+            this.label11.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label11.Name = "label11";
+            this.label11.Size = new System.Drawing.Size(92, 16);
+            this.label11.TabIndex = 21;
+            this.label11.Tag = "iatag_ui_indexing_items";
+            this.label11.Text = "Indexing items";
+            this.label11.UseWaitCursor = true;
             // 
             // progressSavingSpecialStats
             // 
             this.progressSavingSpecialStats.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progressSavingSpecialStats.Location = new System.Drawing.Point(196, 139);
+            this.progressSavingSpecialStats.Location = new System.Drawing.Point(262, 204);
+            this.progressSavingSpecialStats.Margin = new System.Windows.Forms.Padding(4);
             this.progressSavingSpecialStats.Name = "progressSavingSpecialStats";
-            this.progressSavingSpecialStats.Size = new System.Drawing.Size(188, 14);
+            this.progressSavingSpecialStats.Size = new System.Drawing.Size(250, 17);
             this.progressSavingSpecialStats.TabIndex = 11;
             this.progressSavingSpecialStats.UseWaitCursor = true;
             // 
             // label10
             // 
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(3, 136);
+            this.label10.Location = new System.Drawing.Point(4, 200);
+            this.label10.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(101, 13);
+            this.label10.Size = new System.Drawing.Size(127, 16);
             this.label10.TabIndex = 17;
             this.label10.Tag = "iatag_ui_saving_special_stats";
             this.label10.Text = "Saving special stats";
@@ -135,9 +167,10 @@
             // 
             this.progressSkillCorrectnessCheck.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progressSkillCorrectnessCheck.Location = new System.Drawing.Point(196, 179);
+            this.progressSkillCorrectnessCheck.Location = new System.Drawing.Point(262, 254);
+            this.progressSkillCorrectnessCheck.Margin = new System.Windows.Forms.Padding(4);
             this.progressSkillCorrectnessCheck.Name = "progressSkillCorrectnessCheck";
-            this.progressSkillCorrectnessCheck.Size = new System.Drawing.Size(188, 14);
+            this.progressSkillCorrectnessCheck.Size = new System.Drawing.Size(250, 17);
             this.progressSkillCorrectnessCheck.TabIndex = 19;
             this.progressSkillCorrectnessCheck.UseWaitCursor = true;
             // 
@@ -145,18 +178,20 @@
             // 
             this.progressGeneratingSkills.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progressGeneratingSkills.Location = new System.Drawing.Point(196, 159);
+            this.progressGeneratingSkills.Location = new System.Drawing.Point(262, 229);
+            this.progressGeneratingSkills.Margin = new System.Windows.Forms.Padding(4);
             this.progressGeneratingSkills.Name = "progressGeneratingSkills";
-            this.progressGeneratingSkills.Size = new System.Drawing.Size(188, 14);
+            this.progressGeneratingSkills.Size = new System.Drawing.Size(250, 17);
             this.progressGeneratingSkills.TabIndex = 11;
             this.progressGeneratingSkills.UseWaitCursor = true;
             // 
             // label9
             // 
             this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(3, 176);
+            this.label9.Location = new System.Drawing.Point(4, 250);
+            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(94, 13);
+            this.label9.Size = new System.Drawing.Size(116, 16);
             this.label9.TabIndex = 20;
             this.label9.Tag = "iatag_ui_skills_sanity";
             this.label9.Text = "Skills sanity check";
@@ -165,9 +200,10 @@
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(3, 56);
+            this.label5.Location = new System.Drawing.Point(4, 75);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(104, 13);
+            this.label5.Size = new System.Drawing.Size(132, 16);
             this.label5.TabIndex = 11;
             this.label5.Tag = "iatag_ui_mapping_item_names";
             this.label5.Text = "Mapping item names";
@@ -176,9 +212,10 @@
             // label8
             // 
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(3, 156);
+            this.label8.Location = new System.Drawing.Point(4, 225);
+            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(84, 13);
+            this.label8.Size = new System.Drawing.Size(106, 16);
             this.label8.TabIndex = 19;
             this.label8.Tag = "iatag_ui_generating_skills";
             this.label8.Text = "Generating skills";
@@ -188,18 +225,20 @@
             // 
             this.progressMappingPetStats.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progressMappingPetStats.Location = new System.Drawing.Point(196, 79);
+            this.progressMappingPetStats.Location = new System.Drawing.Point(262, 104);
+            this.progressMappingPetStats.Margin = new System.Windows.Forms.Padding(4);
             this.progressMappingPetStats.Name = "progressMappingPetStats";
-            this.progressMappingPetStats.Size = new System.Drawing.Size(188, 14);
+            this.progressMappingPetStats.Size = new System.Drawing.Size(250, 17);
             this.progressMappingPetStats.TabIndex = 14;
             this.progressMappingPetStats.UseWaitCursor = true;
             // 
             // label7
             // 
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(3, 96);
+            this.label7.Location = new System.Drawing.Point(4, 125);
+            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(67, 13);
+            this.label7.Size = new System.Drawing.Size(84, 16);
             this.label7.TabIndex = 15;
             this.label7.Tag = "iatag_ui_saving_items";
             this.label7.Text = "Saving items";
@@ -209,9 +248,10 @@
             // 
             this.progressGeneratingSpecialStats.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progressGeneratingSpecialStats.Location = new System.Drawing.Point(196, 119);
+            this.progressGeneratingSpecialStats.Location = new System.Drawing.Point(262, 179);
+            this.progressGeneratingSpecialStats.Margin = new System.Windows.Forms.Padding(4);
             this.progressGeneratingSpecialStats.Name = "progressGeneratingSpecialStats";
-            this.progressGeneratingSpecialStats.Size = new System.Drawing.Size(188, 14);
+            this.progressGeneratingSpecialStats.Size = new System.Drawing.Size(250, 17);
             this.progressGeneratingSpecialStats.TabIndex = 10;
             this.progressGeneratingSpecialStats.UseWaitCursor = true;
             // 
@@ -219,18 +259,20 @@
             // 
             this.progressMappingItemNames.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progressMappingItemNames.Location = new System.Drawing.Point(196, 59);
+            this.progressMappingItemNames.Location = new System.Drawing.Point(262, 79);
+            this.progressMappingItemNames.Margin = new System.Windows.Forms.Padding(4);
             this.progressMappingItemNames.Name = "progressMappingItemNames";
-            this.progressMappingItemNames.Size = new System.Drawing.Size(188, 14);
+            this.progressMappingItemNames.Size = new System.Drawing.Size(250, 17);
             this.progressMappingItemNames.TabIndex = 12;
             this.progressMappingItemNames.UseWaitCursor = true;
             // 
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(3, 76);
+            this.label6.Location = new System.Drawing.Point(4, 100);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(95, 13);
+            this.label6.Size = new System.Drawing.Size(119, 16);
             this.label6.TabIndex = 13;
             this.label6.Tag = "iatag_ui_preparing_pet_stats";
             this.label6.Text = "Preparing pet stats";
@@ -240,9 +282,10 @@
             // 
             this.progressSaveItems.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progressSaveItems.Location = new System.Drawing.Point(196, 99);
+            this.progressSaveItems.Location = new System.Drawing.Point(262, 129);
+            this.progressSaveItems.Margin = new System.Windows.Forms.Padding(4);
             this.progressSaveItems.Name = "progressSaveItems";
-            this.progressSaveItems.Size = new System.Drawing.Size(188, 14);
+            this.progressSaveItems.Size = new System.Drawing.Size(250, 17);
             this.progressSaveItems.TabIndex = 16;
             this.progressSaveItems.UseWaitCursor = true;
             // 
@@ -250,18 +293,20 @@
             // 
             this.progressLoadingItems.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progressLoadingItems.Location = new System.Drawing.Point(196, 39);
+            this.progressLoadingItems.Location = new System.Drawing.Point(262, 54);
+            this.progressLoadingItems.Margin = new System.Windows.Forms.Padding(4);
             this.progressLoadingItems.Name = "progressLoadingItems";
-            this.progressLoadingItems.Size = new System.Drawing.Size(188, 14);
+            this.progressLoadingItems.Size = new System.Drawing.Size(250, 17);
             this.progressLoadingItems.TabIndex = 6;
             this.progressLoadingItems.UseWaitCursor = true;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(3, 0);
+            this.label1.Location = new System.Drawing.Point(4, 0);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(68, 13);
+            this.label1.Size = new System.Drawing.Size(85, 16);
             this.label1.TabIndex = 3;
             this.label1.Tag = "iatag_ui_loading_tags";
             this.label1.Text = "Loading tags";
@@ -271,18 +316,20 @@
             // 
             this.progressSavingTags.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progressSavingTags.Location = new System.Drawing.Point(196, 21);
+            this.progressSavingTags.Location = new System.Drawing.Point(262, 29);
+            this.progressSavingTags.Margin = new System.Windows.Forms.Padding(4);
             this.progressSavingTags.Name = "progressSavingTags";
-            this.progressSavingTags.Size = new System.Drawing.Size(188, 12);
+            this.progressSavingTags.Size = new System.Drawing.Size(250, 17);
             this.progressSavingTags.TabIndex = 4;
             this.progressSavingTags.UseWaitCursor = true;
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(3, 18);
+            this.label2.Location = new System.Drawing.Point(4, 25);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(63, 13);
+            this.label2.Size = new System.Drawing.Size(78, 16);
             this.label2.TabIndex = 5;
             this.label2.Tag = "iatag_ui_saving_tags";
             this.label2.Text = "Saving tags";
@@ -292,18 +339,20 @@
             // 
             this.progressLoadingTags.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progressLoadingTags.Location = new System.Drawing.Point(196, 3);
+            this.progressLoadingTags.Location = new System.Drawing.Point(262, 4);
+            this.progressLoadingTags.Margin = new System.Windows.Forms.Padding(4);
             this.progressLoadingTags.Name = "progressLoadingTags";
-            this.progressLoadingTags.Size = new System.Drawing.Size(188, 12);
+            this.progressLoadingTags.Size = new System.Drawing.Size(250, 17);
             this.progressLoadingTags.TabIndex = 0;
             this.progressLoadingTags.UseWaitCursor = true;
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(3, 36);
+            this.label3.Location = new System.Drawing.Point(4, 50);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(73, 13);
+            this.label3.Size = new System.Drawing.Size(91, 16);
             this.label3.TabIndex = 7;
             this.label3.Tag = "iatag_ui_loading_items";
             this.label3.Text = "Loading Items";
@@ -312,9 +361,10 @@
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(3, 116);
+            this.label4.Location = new System.Drawing.Point(4, 175);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(120, 13);
+            this.label4.Size = new System.Drawing.Size(151, 16);
             this.label4.TabIndex = 16;
             this.label4.Tag = "iatag_ui_generating_special_stats";
             this.label4.Text = "Generating special stats";
@@ -322,11 +372,12 @@
             // 
             // ParsingDatabaseProgressView
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(425, 248);
+            this.ClientSize = new System.Drawing.Size(567, 338);
             this.Controls.Add(this.groupBox1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "ParsingDatabaseProgressView";
             this.Text = "Parsing database..";
             this.Load += new System.EventHandler(this.ParsingDatabaseProgressView_Load);
@@ -361,5 +412,7 @@
         private System.Windows.Forms.Label label8;
         private System.Windows.Forms.ProgressBar progressSavingSpecialStats;
         private System.Windows.Forms.Label label10;
+        private System.Windows.Forms.Label label11;
+        private System.Windows.Forms.ProgressBar progressIndexItems;
     }
 }

--- a/IAGrim/Parsers/GameDataParsing/UI/ParsingDatabaseProgressView.cs
+++ b/IAGrim/Parsers/GameDataParsing/UI/ParsingDatabaseProgressView.cs
@@ -18,6 +18,7 @@ namespace IAGrim.Parsers.GameDataParsing.UI {
         public ProgressBar MappingItemNames => progressMappingItemNames;
         public ProgressBar MappingPetStats => progressMappingPetStats;
         public ProgressBar SavingItems => progressSaveItems;
+        public ProgressBar IndexingItems => progressIndexItems;
         public ProgressBar GeneratingSpecialStats => progressGeneratingSpecialStats;
         public ProgressBar SavingSpecialStats => progressSavingSpecialStats;
         

--- a/StatTranslator/EnglishLanguage.cs
+++ b/StatTranslator/EnglishLanguage.cs
@@ -604,6 +604,7 @@ namespace StatTranslator {
             {"iatag_ui_mapping_item_names", "Mapping item names"},
             {"iatag_ui_generating_skills", "Generating skills"},
             {"iatag_ui_saving_items", "Saving items"},
+            {"iatag_ui_indexing_items", "Indexing items"},
             {"iatag_ui_preparing_pet_stats", "Preparing pet stats"},
             {"iatag_ui_loading_tags", "Loading tags"},
             {"iatag_ui_saving_tags", "Saving tags"},


### PR DESCRIPTION
When the GD database is loaded, the loader drops and recreates the indexes on the item tables after every batch of items is created. There is no obvious reason to do this and it adds about 50 seconds to the total database-loading time on my machine. This PR makes the loader create the indexes only once after all of the items have been inserted. Since the indexes still take a few seconds to create, it adds an "Indexing items" progress bar to the loader's dialog to make it clear that loading has not stalled.

This PR has been tested with SQLite but not Postgres.