### PR TITLE
Item replicator ignores player items' IsHardcore flag

### DIFF
--- a/IAGrim/Database/DAO/PlayerItemDaoImpl.cs
+++ b/IAGrim/Database/DAO/PlayerItemDaoImpl.cs
@@ -1077,6 +1077,7 @@ DELETE FROM PlayerItem WHERE Id IN (
                 PI.MateriaRecord as MateriaRecord,
                 PI.EnchantmentRecord as EnchantmentRecord,
                 PI.mod as Mod,
+                CAST(PI.{PlayerItemTable.IsHardcore} as bit) as IsHardcore_long,
                 PI.TransmuteRecord as TransmuteRecord
                 FROM PlayerItem PI 
                 WHERE PI.Id NOT IN (SELECT R.PlayerItemId FROM ReplicaItem2 R WHERE R.PlayerItemId IS NOT NULL)

--- a/IAGrim/Database/Model/PlayerItem.cs
+++ b/IAGrim/Database/Model/PlayerItem.cs
@@ -31,6 +31,13 @@ namespace IAGrim.Database {
         public virtual string Rarity { get; set; }
         public string Mod { get; set; }
         public virtual bool IsHardcore { get; set; }
+        /// <summary>
+        /// Workaround for NHibernate issue, when it failed to convert SQLite's INTEGER (it deserializes CAST(... AS BIT) into Int64...) to .net's bool, even with cast (probably, metadata issue).
+        /// </summary>
+        public long IsHardcore_long {
+            get => IsHardcore ? 1 : 0;
+            set => IsHardcore = value != 0;
+        }
 
         public bool IsExpansion1 { get; set; }
 


### PR DESCRIPTION
Hi!

I play Grim Dawn on hardcore, so there are no softcore items in Item Assistant. After case-insensitive search for unicode descriptions was fixed, I tried to update item stats using the button, but the item replication process went into an infinite loop.

Some time later, I noticed that "replica\from_ia\hc" directory in AppData is empty, but "sc" is full. I thought: "Smth went wrong...". After several debug sessions, I noticed that mapping for IsHardcore isn't specified in "select", so all missing replicas "think" they are softcore items.

So, here we are: by adding IsHardcore for the matching property (actually, for `long` property, which properly converts long into bool - honestly, idk why NHibernate doesn't work without it) the GDIA stores those files into "hc" directory - and issue is no longer exists!

p.s. I noticed `BuddyItemDaoImpl` also has `ListMissingReplica` method and there is no mapping for `IsHardcore` property (and for `Mod` property too), but `ItemReplicaService` uses them to build the correct path. Maybe, it has to be fixed too?