### PR TITLE
Fix localization loading (and displaying suffixes too)

### DIFF
--- a/IAGrim/Parsers/Arz/LocalizationLoader.cs
+++ b/IAGrim/Parsers/Arz/LocalizationLoader.cs
@@ -127,7 +127,7 @@ namespace IAGrim.Parsers.Arz {
             foreach (var line in data.Split('\n')) {
                 var sline = line.Split('=');
                 if (sline.Length == 2) {
-                    result[sline[0].Trim()] = sline[1].Replace("^k", "");
+                    result[sline[0].Trim()] = sline[1].Replace("^k", "").TrimEnd('\r');
                 }
             }
 


### PR DESCRIPTION
Another fix for non-English localizations :)

As of now, are not displayed in IA for some languages (e.g. for Russian):

<details><summary>Item in Item Assistant:</summary>
<p>

![p1_before_ia](https://github.com/user-attachments/assets/6da0ad3a-97c4-4363-abaa-be1cc4f7becc)

</p>
</details>
<details><summary>Item in Grim Dawn:</summary>
<p>

![p1_before_gd](https://github.com/user-attachments/assets/80d24cbc-100d-41ff-900c-09c7b9910cf1)

</p>
</details>

As you can see, there is no suffix ("готовности") in GDIA, but the game displays it.

It turned out that GD's localization files use CRLF line endings, but IA splits lines by '\n', so each line ends with CR char.

After this fix items are displayed correctly:

<details><summary>Picture:</summary>
<p>

![p3_after_ia](https://github.com/user-attachments/assets/aa921b70-a5af-4ced-8e59-1cd83cfbe2c6)

</p>
</details> 

p.s. Oops! It seems that there was #141 regarding exactly the same bug, but it appears that the issue still persists.
p.p.s. Originally, I thougth about trimming this \r just there:

<details><summary>Details</summary>
<p>

![image](https://github.com/user-attachments/assets/f2eb9354-5335-40c6-9b88-286dce5193c0)
p.p.p.s. `ItemNameCombinator` incorrectly handled it.

</p>
</details>

but decided to trim it everywhere, because there can be other places like this one, which were broken due to this line ending char.