### PR TITLE
Typo in ReplicaStat.css

### DIFF
--- a/WebUI/src/containers/ReplicaStat.css
+++ b/WebUI/src/containers/ReplicaStat.css
@@ -15,7 +15,7 @@
 
 
 /* 64: Slot & Quality, ex: Epic Ring, 3: No idea.. buddyitems? */
-.replica-type-64, replica-type-3 {
+.replica-type-64, .replica-type-3 {
   display: none;
 }
 


### PR DESCRIPTION
Hi!

Just found a typo in ReplicaStat.css.

P.S. FYI, replica type 3 is a name of yellow item. Items of other rarities don't have it.
P.P.S. Don't ask me, why I even keep yellow ones. :D