### PR TITLE
webui: fix coloring for set skills

### DIFF
--- a/WebUI/src/components/Item/ReplicaStatContainer.tsx
+++ b/WebUI/src/components/Item/ReplicaStatContainer.tsx
@@ -60,6 +60,8 @@ class ReplicaStatContainer extends PureComponent<Props, object> {
       return false;
     }
 
+    let setSkillStage = 0;
+
     let hasShownSkills = false;
     return (
       <p className="replica">
@@ -67,6 +69,31 @@ class ReplicaStatContainer extends PureComponent<Props, object> {
           // Skip skill information
           if (shouldSkip(row)) {
             return null;
+          }
+
+          if (row.type === 80 /* Set skill, e.g. Secrets of the Guardian (50% Chance on Critical Attack) */) {
+            // All rows of this skill's info have type 80, so these rows are rendered as plain black text (in dark mode)
+
+            // With the following "state machine", "80" types are replaced with more appropriate ones:
+            // setSkillStage=0 => render with type=23 // Skill name
+            // setSkillStage=1 => render with type=21 // Skill description
+            // setSkillStage=2 => render with type=40 // Skill stat row
+            // setSkillStage=3 => render with type=40
+            // setSkillStage=4 => render with type=40
+            // etc...
+            let replicaStat;
+
+            if (setSkillStage === 0) {
+              replicaStat = <ReplicaStat {...row} key={id + idx} type={23}/>
+            } else if (setSkillStage === 1) {
+              replicaStat = <ReplicaStat {...row} key={id + idx} type={21}/>
+            } else if (setSkillStage > 1) {
+              replicaStat = <ReplicaStat {...row} key={id + idx} type={40}/>
+            }
+
+            ++setSkillStage;
+
+            return replicaStat;
           }
 
           if (row.type === 0 /* Newline */) {


### PR DESCRIPTION
Hi! Another set of fixes :)

Long story short: set skills are rendered as a black text in dark mode:

<details><summary>Bad coloring</summary>
<p>

![2025-02-issue2-setskill-bad](https://github.com/user-attachments/assets/3fce52de-3fbb-49a0-aaec-3cd1f70a8864)

</p>
</details> 

Еhis happens because the stats for the set skill have type 80 instead the correct ones.

So, this fix replaces set name's type with 23, description with 21, and other stats with 40. This results into this beautiful image:

<details><summary>Correctly colored rows</summary>
<p>

![2025-02-issue2-setskill-bad-fixed](https://github.com/user-attachments/assets/c91d2fd6-f424-4900-ab97-e153a89d6df4)

</p>
</details> 

P.S. I've looked at the sqlite database, and saw that in the following table only the rows for set skills have type 80, so nothing (probably) will be broken.

<details><summary>Screenshot of the table</summary>
<p>

![2025-02-issue2-setskill-db](https://github.com/user-attachments/assets/b7da8a44-a052-45ac-8c64-ce1759c1fff2)

</p>
</details> 