### PR TITLE
Fix an issue searching for items in sets in non-English locales

### DIFF
--- a/IAGrim/Database/DAO/Table/DatabaseItemTable.cs
+++ b/IAGrim/Database/DAO/Table/DatabaseItemTable.cs
@@ -10,6 +10,7 @@ namespace IAGrim.Database.DAO.Table {
         public const string Id = "id_databaseitem";
         public const string Record = "baserecord";
         public const string Name = "name";
+        public const string NameLowercase = "namelowercase";
         public const string Hash = "hash";
     }
 }

--- a/IAGrim/Database/Model/DatabaseItem.cs
+++ b/IAGrim/Database/Model/DatabaseItem.cs
@@ -18,6 +18,8 @@ namespace IAGrim.Database {
 
         public virtual string Name { set; get; }
 
+        public virtual string NameLowercase { get; set; }
+
         public virtual string GetTag(string tag) {
             if (Stats.Any(m => tag.Equals(m.Stat)))
                 return Stats.FirstOrDefault(m => tag.Equals(m.Stat))?.TextValue;

--- a/IAGrim/Database/Model/DatabaseItem.hbm.xml
+++ b/IAGrim/Database/Model/DatabaseItem.hbm.xml
@@ -18,6 +18,7 @@
     </bag>
 
     <property name="Name" column="name"/>
+    <property name="NameLowercase" column="namelowercase"/>
     <property name="Hash" column="hash"/>
     
   </class>

--- a/IAGrim/Parsers/GameDataParsing/Service/ArzParsingWrapper.cs
+++ b/IAGrim/Parsers/GameDataParsing/Service/ArzParsingWrapper.cs
@@ -129,6 +129,7 @@ namespace IAGrim.Parsers.GameDataParsing.Service {
                     }
 
                     Items[i].Name = string.Join(" ", finalTags).Trim();
+                    Items[i].NameLowercase = Items[i].Name.ToLowerInvariant();
                 }
 
                 tracker.Increment();

--- a/IAGrim/UI/Controller/SearchController.cs
+++ b/IAGrim/UI/Controller/SearchController.cs
@@ -52,7 +52,9 @@ namespace IAGrim.UI.Controller {
         private void UpdateCollectionItems(ItemSearchRequest query) {
             Thread thread = new Thread(() => {
                 ExceptionReporter.EnableLogUnhandledOnThread();
-                Browser.SetCollectionItems(_itemCollectionRepo.GetItemCollection(query));
+
+                var itemCollection = _itemCollectionRepo.GetItemCollection(query);
+                Browser.SetCollectionItems(itemCollection);
             });
             thread.Start();
 

--- a/StatTranslator/EnglishLanguage.cs
+++ b/StatTranslator/EnglishLanguage.cs
@@ -790,6 +790,10 @@ namespace StatTranslator {
             return _itemCombinator.TranslateName(prefix, quality, style, name, suffix);
         }
 
+        public string TranslateName(string rawName) {
+            return _itemCombinator.TranslateName(rawName);
+        }
+
         public string[] Serialize() {
             return _stats.Keys.ToArray();
         }

--- a/StatTranslator/ILocalizedLanguage.cs
+++ b/StatTranslator/ILocalizedLanguage.cs
@@ -6,6 +6,8 @@
 
         string TranslateName(string prefix, string quality, string style, string name, string suffix);
 
+        string TranslateName(string rawName);
+
         bool WarnIfMissing { get; }
     }
 }

--- a/StatTranslator/ThirdPartyLanguage.cs
+++ b/StatTranslator/ThirdPartyLanguage.cs
@@ -28,6 +28,10 @@ namespace StatTranslator {
             return _itemCombinator.TranslateName(prefix, quality, style, name, suffix);
         }
 
+        public string TranslateName(string rawName) {
+            return _itemCombinator.TranslateName(rawName);
+        }
+
         public string GetTag(string tag) {
             if (_stats.ContainsKey(tag)) {
                 return _stats[tag];


### PR DESCRIPTION
Hi! The last one for today :)

Before this fix:

<details><summary>Set items are not parsed</summary>
<p>

![2025-02-issue3-ru-bad](https://github.com/user-attachments/assets/762e9d9c-c76e-4afc-8941-7233d6dd30fd)

</p>
</details>

IAGD couldn't find the items for the [Dagallon's Destruction](https://www.grimtools.com/db/itemsets/121) set.

<details><summary>After the fix</summary>
<p>

![2025-02-issue3-ru-fixed](https://github.com/user-attachments/assets/0a7c3e27-cd6e-4018-ae1c-2b19bfa59249)

</p>
</details>

Now, IAGD properly parses "gendered" names, and correctly finds the other items from the set.

About the implementation:
1 NameLowerCase column has been added into `DatabaseItem` table. Based on [(Hopefully) fixed an issue searching for item text in foreign languages](https://github.com/marius00/iagd/commit/e088fa71e44fb1269596aa8c1a186950989d2e88) commit. Probably, I missed something, but it works locally.
2 "Ungender" item names, e.g. `"[ms]MaleVariantOfMystical[fs]FemaleVariantOfMystical [fs]Item"` into `"FemaleVariantOfMystical Item"`.
P.S. this change, surprisingly, fixed the Collection tab for non-English languages too (no more very long ungendered names).
3 (misc) Slightly optimize `GetGendered` method: internally, `Regex.Match` caches regular expressions, so there is no need to create new `Regex` objectes and pollute the heap.