### PR TITLE
FG items localization 

### DIFF
--- a/IAGrim/Parsers/Arz/LocalizationLoader.cs
+++ b/IAGrim/Parsers/Arz/LocalizationLoader.cs
@@ -181,7 +181,13 @@ namespace IAGrim.Parsers.Arz {
 
             try {
                 using (ZipFile zip = ZipFile.Read(filename)) {
-                    foreach (var itemsFile in zip.EntryFileNames.Where(m => m.Contains("items") || m.Contains("skills"))) {
+                    foreach (var itemsFile in
+                        zip.EntryFileNames
+                            .Where(m =>
+                                m.Contains("items")
+                                    || m.Contains("skills")
+                                    || m.Contains("endlessdungeon"))) // fg dir has tagsgdx2_endlessdungeon.txt file, which also has localization for items
+                    {
                         var tags = ReadFile(zip, itemsFile);
                         _tagsItems = Merge(_tagsItems, tags);
                     }


### PR DESCRIPTION
I remember you said that in future iagd will retrieve item names from GD instead of localization files, but before that I've prepared a small fix for FG's special items:

I was always curious, why `Miss Gazer Man` was named as tagGDX2ItemTest. Well, the root cause is that iagd doesn't read endlessdungeon file (or the localization guy did something wrong, and put these records in the wrong file :D)
![2025-03-fg-items](https://github.com/user-attachments/assets/8b082dd8-3815-4ddb-abe0-a923b7dfd104)
