### PR TITLE
Rework Other filter

### DIFF
--- a/IAGrim/Database/DAO/PlayerItemDaoImpl.cs
+++ b/IAGrim/Database/DAO/PlayerItemDaoImpl.cs
@@ -790,7 +790,7 @@ namespace IAGrim.Database {
                 )
                 ";
 
-                sql.Add($" AND PI.Id IN ({subQuerySql})");
+                sql.Add($" AND PI.Id {(query.SlotInverse ? "NOT" : "")} IN ({subQuerySql})");
 
                 // ItemRelic = Components, we don't want to find every item that has a component, only those that are one.
                 if (query.Slot.Length == 1 && query.Slot[0] == "ItemRelic") {

--- a/IAGrim/Database/Dto/ItemSearchRequest.cs
+++ b/IAGrim/Database/Dto/ItemSearchRequest.cs
@@ -13,6 +13,14 @@ namespace IAGrim.Database.Dto {
         public float MaximumLevel { get; set; }
         public string Rarity { get; set; }
         public string[] Slot { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the search should exclude items with types specified in the <see cref="Slot"/> array.
+        /// If <see langword="true"/>, items with types in <see cref="Slot"/> will be excluded.
+        /// If <see langword="false"/>, items with types in <see cref="Slot"/> will be included.
+        /// </summary>
+        public bool SlotInverse { get; set; }
+
         public bool PetBonuses { get; set; }
         public bool IsRetaliation { get; set; }
         public bool DuplicatesOnly { get; set; }

--- a/IAGrim/Theme/ComboBoxItem.cs
+++ b/IAGrim/Theme/ComboBoxItem.cs
@@ -5,14 +5,11 @@ using System.Text;
 
 namespace IAGrim.Theme {
     class ComboBoxItem {
-        public string[] Filter {
-            get;
-            set;
-        }
-        public string Text {
-            get;
-            set;
-        }
+        public string[] Filter { get; set; }
+
+        public bool Inverse { get; set; }
+
+        public string Text { get; set; }
 
         public override string ToString() {
             return Text;

--- a/IAGrim/UI/Tabs/SplitSearchWindow.cs
+++ b/IAGrim/UI/Tabs/SplitSearchWindow.cs
@@ -157,6 +157,7 @@ namespace IAGrim.UI.Tabs {
                 Rarity = rarity?.Rarity,
                 PrefixRarity = rarity?.PrefixRarity ?? 0,
                 Slot = slot?.Filter,
+                SlotInverse = slot?.Inverse ?? false,
                 PetBonuses = filters.PetBonuses,
                 IsRetaliation = filters.IsRetaliation,
                 DuplicatesOnly = filters.DuplicatesOnly,

--- a/IAGrim/UI/UIHelper.cs
+++ b/IAGrim/UI/UIHelper.cs
@@ -185,7 +185,8 @@ namespace IAGrim.UI
                 slotFilter.Add(new ComboBoxItem
                 {
                     Text = language.GetTag("iatag_slot_other"),
-                    Filter = otherTable.ToArray<string>()
+                    Filter = otherTable.ToArray<string>(),
+                    Inverse = true,
                 });
 
 


### PR DESCRIPTION
This PR reworks Other filter: if Other is selected, items of other types (e.g. mandates and warrants) are displayed.

![reworked-other-filter](https://github.com/user-attachments/assets/0f64c760-747a-4e72-b667-7fac9bda2a79)

P.S. I mentioned this in #262, but I'm not sure I understand the logic of current Other filter correctly. So, I've remade it a bit, and now it make senses to me. :)