### PR TITLE
UI layout fixes for high DPI screens / display scaling

### DIFF
--- a/IAGrim/IAGrim.csproj
+++ b/IAGrim/IAGrim.csproj
@@ -18,6 +18,8 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <PlatformTarget>x64</PlatformTarget>
+
+	<ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
   </PropertyGroup>
    <PropertyGroup> 
     <ContentSQLiteInteropFiles>true</ContentSQLiteInteropFiles>

--- a/IAGrim/Theme/CollapseablePanelBox.cs
+++ b/IAGrim/Theme/CollapseablePanelBox.cs
@@ -9,8 +9,8 @@ using System.Windows.Forms;
 
 namespace IAGrim.Theme {
     class CollapseablePanelBox : PanelBox {
-        private const int margin = 3;
-        private const int size = 24;
+        private readonly Size margin;
+        private readonly Size imageSize;
         private Image _arrow;
         private readonly Image _arrowImageUp = global::IAGrim.Properties.Resources.arrow;
         private readonly Image _arrowImageDown = global::IAGrim.Properties.Resources.arrow;
@@ -26,13 +26,17 @@ namespace IAGrim.Theme {
 
             // Position the arrow correctly in the top right corner
             _arrow = _arrowImageDown;
+
+            DpiHelper dpiHelper = new DpiHelper(CreateGraphics());
+            margin = dpiHelper.ScaleSize(new Size(3, 3));
+            imageSize = dpiHelper.ScaleSize(new Size(24, 24));
         }
 
 
         protected override void OnPaint(PaintEventArgs e) {
             base.OnPaint(e);
             if (this.Width != 0 && this.Height != 0) {
-                e.Graphics.DrawImage(this._arrow, Width - margin - size, margin, size, size);
+                e.Graphics.DrawImage(this._arrow, Width - margin.Width - imageSize.Width, margin.Height, imageSize.Width, imageSize.Height);
             }
         }
 
@@ -42,7 +46,7 @@ namespace IAGrim.Theme {
 
             if (_panelState == PanelState.Collapsed) {
                 _originalHeight = Height;
-                Height = 32;
+                Height = new DpiHelper(CreateGraphics()).ScaleY(32);
             }
             else {
                 Height = _originalHeight;
@@ -59,7 +63,7 @@ namespace IAGrim.Theme {
             base.OnMouseUp(e);
 
             if (Enabled) {
-                if (e.Y < size) {
+                if (e.Y < (imageSize.Height + margin.Height * 2)) {
                     ToggleState();
                 }
             }
@@ -68,7 +72,7 @@ namespace IAGrim.Theme {
         }
 
         protected override void OnMouseMove(MouseEventArgs e) {
-            if (e.Y < size) {
+            if (e.Y < (imageSize.Height + margin.Height * 2)) {
                 Cursor.Current = Cursors.Hand;
             }
         }

--- a/IAGrim/Theme/DpiHelper.cs
+++ b/IAGrim/Theme/DpiHelper.cs
@@ -1,0 +1,51 @@
+﻿namespace IAGrim.Theme {
+    /// <summary>
+    /// Helper class to scale absolute pixel values to units appropriate for the current display DPI/scale factor.
+    /// </summary>
+    internal class DpiHelper {
+        /// <summary>
+        /// This is Windows' default DPI. UI elements are designed and laid out based on this DPS.
+        /// </summary>
+        private const float BASE_DPI = 96.0f;
+
+        private readonly float _scaleFactorX;
+
+        private readonly float _scaleFactorY;
+
+        public DpiHelper(Graphics g) {
+            _scaleFactorX = g.DpiX / BASE_DPI;
+            _scaleFactorY = g.DpiY / BASE_DPI;
+        }
+
+        public int ScaleX(int x) {
+            return (int)(x * _scaleFactorX);
+        }
+
+        public float ScaleX(float x) {
+            return x * _scaleFactorX;
+        }
+
+        public int ScaleY(int y) {
+            return (int)(y * _scaleFactorY);
+        }
+        public float ScaleY(float y) {
+            return y * _scaleFactorY;
+        }
+
+        public Point ScalePoint(Point p) {
+            return new Point(ScaleX(p.X), ScaleY(p.Y));
+        }
+
+        public PointF ScalePoint(PointF p) {
+            return new PointF(ScaleX(p.X), ScaleY(p.Y));
+        }
+
+        public Size ScaleSize(Size s) {
+            return new Size(ScaleX(s.Width), ScaleY(s.Height));
+        }
+
+        public Rectangle ScaleRectangle(Rectangle r) {
+            return new Rectangle(ScalePoint(r.Location), ScaleSize(r.Size));
+        }
+    }
+}

--- a/IAGrim/Theme/Firefox/FirefoxCheckBox.cs
+++ b/IAGrim/Theme/Firefox/FirefoxCheckBox.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using IAGrim.Theme;
+using System;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -94,6 +95,11 @@ class FirefoxCheckBox : CheckBox {
 
         G.Clear(Parent.BackColor);
 
+        DpiHelper dpiHelper = new DpiHelper(G);
+        Rectangle checkboxRect = dpiHelper.ScaleRectangle(new Rectangle(3, 3, 20, 20));
+        Point checkmarkPosition = dpiHelper.ScalePoint(new Point(4, 5));
+        Point textPosition = dpiHelper.ScalePoint(new Point(32, 4));
+
         if (Enabled) {
             ETC = ForeColor;
 
@@ -101,11 +107,11 @@ class FirefoxCheckBox : CheckBox {
 
                 case Helpers.MouseState.Over:
                 case Helpers.MouseState.Down:
-                    Helpers.DrawRoundRect(G, new Rectangle(3, 3, 20, 20), 3, Color.FromArgb(44, 156, 218));
+                    Helpers.DrawRoundRect(G, checkboxRect, 3, Color.FromArgb(44, 156, 218));
 
                     break;
                 default:
-                    Helpers.DrawRoundRect(G, new Rectangle(3, 3, 20, 20), 3, Helpers.GreyColor(200));
+                    Helpers.DrawRoundRect(G, checkboxRect, 3, Helpers.GreyColor(200));
 
                     break;
             }
@@ -113,7 +119,7 @@ class FirefoxCheckBox : CheckBox {
 
             if (Checked) {
                 using (Image I = Image.FromStream(new System.IO.MemoryStream(checkMarkBytes))) {
-                    G.DrawImage(I, new Point(4, 5));
+                    G.DrawImage(I, checkmarkPosition);
                 }
 
             }
@@ -122,12 +128,12 @@ class FirefoxCheckBox : CheckBox {
         }
         else {
             ETC = Helpers.GreyColor(170);
-            Helpers.DrawRoundRect(G, new Rectangle(3, 3, 20, 20), 3, Helpers.GreyColor(220));
+            Helpers.DrawRoundRect(G, checkboxRect, 3, Helpers.GreyColor(220));
 
 
             if (Checked) {
                 using (Image I = Image.FromStream(new System.IO.MemoryStream(checkMarkBytes))) {
-                    G.DrawImage(I, new Point(4, 5));
+                    G.DrawImage(I, checkmarkPosition);
                 }
 
             }
@@ -138,10 +144,10 @@ class FirefoxCheckBox : CheckBox {
         using (SolidBrush B = new SolidBrush(ETC)) {
 
             if (Bold) {
-                G.DrawString(Text, Theme.GlobalFont(FontStyle.Bold, 10), B, new Point(32, 4));
+                G.DrawString(Text, Theme.GlobalFont(FontStyle.Bold, 10), B, textPosition);
             }
             else {
-                G.DrawString(Text, Theme.GlobalFont(FontStyle.Regular, 10), B, new Point(32, 4));
+                G.DrawString(Text, Theme.GlobalFont(FontStyle.Regular, 10), B, textPosition);
             }
 
         }

--- a/IAGrim/Theme/PanelBox.cs
+++ b/IAGrim/Theme/PanelBox.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using IAGrim.Theme;
+using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Text;
@@ -53,9 +54,11 @@ internal class PanelBox : ScrollableControl {
         Brush colorContent = new SolidBrush(BackColor);
         Pen colorBorder = new Pen(Color.FromArgb(214, 214, 214));
         SolidBrush brush = new SolidBrush(ForeColor);
-        try {
+        DpiHelper dpiHelper = new DpiHelper(G);
 
-            int headerHeight = Math.Min(HeaderHeight, this.Height);
+        try {
+            int headerHeight = Math.Min(dpiHelper.ScaleY(HeaderHeight), this.Height);
+            PointF textLocation = dpiHelper.ScalePoint(_textLocation);
             Rectangle rect;
 
             checked {
@@ -77,7 +80,7 @@ internal class PanelBox : ScrollableControl {
                     G.SmoothingMode = SmoothingMode.HighQuality;
                     //G.TextRenderingHint = TextRenderingHint.SingleBitPerPixelGridFit;
                     G.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
-                    G.DrawString(this.Text, this.Font, brush, _textLocation);
+                    G.DrawString(this.Text, this.Font, brush, textLocation);
                 }
 
             }

--- a/IAGrim/Theme/Theme.cs
+++ b/IAGrim/Theme/Theme.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using IAGrim.Theme;
+using System;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -185,6 +186,11 @@ class FirefoxRadioButton : Control {
 
         G.Clear(Parent.BackColor);
 
+        DpiHelper dpiHelper = new DpiHelper(G);
+        Rectangle radioCircleRect = dpiHelper.ScaleRectangle(new Rectangle(2, 2, 22, 22));
+        Rectangle checkedCircleRect = dpiHelper.ScaleRectangle(new Rectangle(7, 7, 12, 12));
+        Point textLocation = dpiHelper.ScalePoint(new Point(32, 4));
+
         if (Enabled) {
             ETC = Color.FromArgb(66, 78, 90);
 
@@ -193,7 +199,7 @@ class FirefoxRadioButton : Control {
                 case Helpers.MouseState.Down:
 
                     using (Pen P = new Pen(Color.FromArgb(34, 146, 208))) {
-                        G.DrawEllipse(P, new Rectangle(2, 2, 22, 22));
+                        G.DrawEllipse(P, radioCircleRect);
                     }
 
 
@@ -201,7 +207,7 @@ class FirefoxRadioButton : Control {
                 default:
 
                     using (Pen P = new Pen(Helpers.GreyColor(190))) {
-                        G.DrawEllipse(P, new Rectangle(2, 2, 22, 22));
+                        G.DrawEllipse(P, radioCircleRect);
                     }
 
 
@@ -211,7 +217,7 @@ class FirefoxRadioButton : Control {
 
             if (Checked) {
                 using (SolidBrush B = new SolidBrush(Color.FromArgb(34, 146, 208))) {
-                    G.FillEllipse(B, new Rectangle(7, 7, 12, 12));
+                    G.FillEllipse(B, checkedCircleRect);
                 }
             }
         }
@@ -219,23 +225,23 @@ class FirefoxRadioButton : Control {
             ETC = Helpers.GreyColor(170);
 
             using (Pen P = new Pen(Helpers.GreyColor(210))) {
-                G.DrawEllipse(P, new Rectangle(2, 2, 22, 22));
+                G.DrawEllipse(P, radioCircleRect);
             }
 
 
             if (Checked) {
                 using (SolidBrush B = new SolidBrush(Color.FromArgb(34, 146, 208))) {
-                    G.FillEllipse(B, new Rectangle(7, 7, 12, 12));
+                    G.FillEllipse(B, checkedCircleRect);
                 }
             }
         }
 
         using (SolidBrush B = new SolidBrush(ETC)) {
             if (Bold) {
-                G.DrawString(Text, Theme.GlobalFont(FontStyle.Bold, 10), B, new Point(32, 4));
+                G.DrawString(Text, Theme.GlobalFont(FontStyle.Bold, 10), B, textLocation);
             }
             else {
-                G.DrawString(Text, Theme.GlobalFont(FontStyle.Regular, 10), B, new Point(32, 4));
+                G.DrawString(Text, Theme.GlobalFont(FontStyle.Regular, 10), B, textLocation);
             }
         }
     }

--- a/IAGrim/UI/MainWindow.Designer.cs
+++ b/IAGrim/UI/MainWindow.Designer.cs
@@ -173,7 +173,6 @@
             tabPageMods.Location = new Point(4, 24);
             tabPageMods.Margin = new Padding(4, 3, 4, 3);
             tabPageMods.Name = "tabPageMods";
-            tabPageMods.Padding = new Padding(4, 3, 4, 3);
             tabPageMods.Size = new Size(1202, 594);
             tabPageMods.TabIndex = 4;
             tabPageMods.Tag = "iatag_ui_tab_mods";

--- a/IAGrim/UI/Tabs/ModsDatabaseConfig.Designer.cs
+++ b/IAGrim/UI/Tabs/ModsDatabaseConfig.Designer.cs
@@ -138,8 +138,7 @@
             // listViewInstalls
             // 
             this.listViewInstalls.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
+            | System.Windows.Forms.AnchorStyles.Left))));
             this.listViewInstalls.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.columnHeader1,
             this.columnHeader3});

--- a/IAGrim/UI/Tabs/SplitSearchWindow.cs
+++ b/IAGrim/UI/Tabs/SplitSearchWindow.cs
@@ -37,7 +37,7 @@ namespace IAGrim.UI.Tabs {
         private readonly SettingsService _settings;
         private ToolTip toolTip1;
         private System.ComponentModel.IContainer components;
-        private const int FilterPanelMinSize = 250;
+        private readonly int FilterPanelMinSize;
         private Microsoft.Web.WebView2.WinForms.WebView2 webView21;
         private Label label1;
         private bool _hasCheckedModFilterNotEmpty = false;
@@ -68,6 +68,8 @@ namespace IAGrim.UI.Tabs {
             InitializeComponent();
 
             Dock = DockStyle.Fill;
+
+            FilterPanelMinSize = new DpiHelper(CreateGraphics()).ScaleX(250);
 
             // Weird hack to not have the searcbox be height=4 on windows 11. 
             _searchBox.MaximumSize = new Size(_searchBox.MaximumSize.Width, 0);


### PR DESCRIPTION
Thank you for Item Assistant and all the work you have done here!

I'm using a 4k screen with a native resolution of 3840x2160 and a display scale factor of 200%. In effect, this gives my screen a virtual resolution of 1920x1080, but with four physical pixels per virtual pixel. When running Item Assistant, most of the core UI elements are scaled fine. Some custom UI elements use fixed pixel sizes for drawing, and thus aren't properly scaled with the rest of the UI. Examples include FirefoxCheckbox/Radiobox, the header of PanelBox, and CollapseablePanelBox when collapsed. The "Grim Dawn" tab seems somewhat broken in particular, and doesn't show the two tables unless the window size is increased/maximized.

Examples:
<img width="1685" height="1372" alt="ia-grimdawntab" src="https://github.com/user-attachments/assets/252fef0a-2105-4996-b580-07458f29d5df" />
<img width="1685" height="1372" alt="ia-settingstab" src="https://github.com/user-attachments/assets/99244afd-71f5-4689-a02a-4c2d09d666df" />
<img width="1685" height="1372" alt="ia-itemstab" src="https://github.com/user-attachments/assets/4e9366e1-f7eb-4462-8d8f-352f83ff7398" />

I added a DpiHelper class that can be used to recalculate fixed pixel sizes based on the current screen DPI. These adjusted pixel values have been used to fix the most glaring problems.

If there are any code style or other issues that you'd like to have fixed, feel free to leave a comment.