### PR TITLE
Fix blank item grid under Wine/Proton (disable sandbox/GPU for WebView2)

### DIFF
--- a/IAGrim/UI/Tabs/SplitSearchWindow.cs
+++ b/IAGrim/UI/Tabs/SplitSearchWindow.cs
@@ -92,7 +92,19 @@ namespace IAGrim.UI.Tabs {
                 ? Color.Black
                 : Color.FromArgb(85, 68, 96);
 
-            var conf = CoreWebView2Environment.CreateAsync(null, GlobalPaths.EdgeCacheLocation).Result;
+            // WINE PATCH: the Chromium sandbox and GPU/renderer subprocesses fail to spawn reliably under
+            // Wine (especially while Grim Dawn is running), so WebView2 navigation never completes and the
+            // item grid stays blank. --no-sandbox + --disable-gpu + --single-process avoids the failing
+            // subprocess/sandbox path so the page renders regardless of Grim Dawn. Applied ONLY under Wine
+            // so Windows keeps its default (sandboxed, GPU-accelerated, multi-process) behaviour untouched.
+            CoreWebView2Environment conf;
+            if (IAGrim.Services.WineDetector.IsRunningInWine()) {
+                var envOptions = new CoreWebView2EnvironmentOptions { AdditionalBrowserArguments = "--no-sandbox --disable-gpu --disable-gpu-compositing --single-process" };
+                conf = CoreWebView2Environment.CreateAsync(null, GlobalPaths.EdgeCacheLocation, envOptions).Result;
+            }
+            else {
+                conf = CoreWebView2Environment.CreateAsync(null, GlobalPaths.EdgeCacheLocation).Result;
+            }
             webView21!.EnsureCoreWebView2Async(conf);
 
             InitializeFilterPanel();


### PR DESCRIPTION
## Problem

On Linux via Steam Proton (Wine), the item grid stays blank while Grim Dawn is running. The logs show WebView2 initialises, but `Browser_NavigationCompleted` never fires (`WebView2 navigation succeeded/failed` is never logged), so the WebUI page never finishes loading, never signals readiness, and every message is queued forever (`browser not yet initialized, queued: SetItems` repeats indefinitely).

Root cause: under Wine the Chromium sandbox and the GPU/renderer subprocesses fail to spawn reliably — noticeably worse while Grim Dawn is holding the GPU (DXVK/vkd3d) — which hangs the WebView2 navigation.

## Fix

Pass `--no-sandbox --disable-gpu --disable-gpu-compositing --single-process` via `CoreWebView2EnvironmentOptions.AdditionalBrowserArguments`. With these, navigation completes, the page loads and the WebUI signals readiness normally.

The arguments are applied **only under Wine** (`WineDetector.IsRunningInWine()`), so native Windows is completely unaffected and keeps its default sandboxed, GPU-accelerated, multi-process behaviour.

Note: the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` environment variable does not help here, because IAGD creates its own `CoreWebView2Environment`; the arguments have to be set programmatically.

## Testing

- Linux (CachyOS + KDE, Steam Proton Experimental, NVIDIA): the item grid now renders with Grim Dawn running. Log shows `WebView2 navigation succeeded` and `UI signalled readiness`. Item transfer continues to work.
- Windows code path is unchanged (guarded by the Wine check).

This addresses the long-standing "blank item list / can't run Grim Dawn and Item Assistant at the same time" reports from Linux users on the guide thread.