### PR TITLE
Hook Fixes for Replica Ascendant and FileWatcher

### DIFF
--- a/HookDll/Hook/InventorySack_AddItem.cpp
+++ b/HookDll/Hook/InventorySack_AddItem.cpp
@@ -412,6 +412,7 @@ bool InventorySack_AddItem::Persist(
 	const std::vector<GAME::GameTextLine>& gameTextLines)
 {
 	std::wstring fullPath = m_storageFolder + randomFilename();
+	std::wstring fullPathTmp = fullPath + L".tmp";
 
 	// Use std::ofstream (narrow) and convert all wide strings to UTF-8 explicitly.
 	// std::wofstream converts through the system ANSI codepage, which destroys
@@ -419,7 +420,7 @@ bool InventorySack_AddItem::Persist(
 	std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> utf8conv;
 
 	std::ofstream stream;
-	stream.open(fullPath, std::ios::binary);
+	stream.open(fullPathTmp, std::ios::binary);
 
 	// Write UTF-8 BOM so readers can detect encoding
 	stream << "\xEF\xBB\xBF";
@@ -446,9 +447,11 @@ bool InventorySack_AddItem::Persist(
 		std::to_wstring(gameTextLines.size()) + L" stat lines)");
 
 	std::ifstream verification;
-	verification.open(fullPath);
+	verification.open(fullPathTmp);
 	if (verification) {
-		return true;
+		verification.close();
+		if (MoveFileW(fullPathTmp.c_str(), fullPath.c_str()))
+			return true;
 	}
 
 	LogToFile(LogLevel::WARNING, L"Error: written CSV file does not exist");

--- a/HookDll/Hook/OnDemandSeedInfo.cpp
+++ b/HookDll/Hook/OnDemandSeedInfo.cpp
@@ -186,8 +186,8 @@ ParsedSeedRequest* OnDemandSeedInfo::DeserializeReplicaCsv(std::vector<std::stri
 	item.transmuteRecord = tokens.at(idx++);
 
 	if (isNewDlc) {
-		auto ascendantAffixNameRecord  = tokens.at(idx++);
-		auto ascendantAffix2hNameRecord= tokens.at(idx++);
+		item.ascendant1 = tokens.at(idx++);
+		item.ascendant2 = tokens.at(idx++);
 	}
 
 	std::string s;
@@ -203,7 +203,8 @@ ParsedSeedRequest* OnDemandSeedInfo::DeserializeReplicaCsv(std::vector<std::stri
 	boost::algorithm::trim(item.materiaRecord);
 	boost::algorithm::trim(item.enchantmentRecord);
 	boost::algorithm::trim(item.transmuteRecord);
-	// TODO: !! Trip ascendant records
+	boost::algorithm::trim(item.ascendant1);
+	boost::algorithm::trim(item.ascendant2);
 
 	result->itemReplicaInfo = item;
 
@@ -364,8 +365,9 @@ boost::property_tree::ptree toJson(ParsedSeedRequest obj, std::vector<GAME::Game
 	replica.put("relicSeed", obj.itemReplicaInfo.relicSeed);
 	replica.put("enchantmentRecord", obj.itemReplicaInfo.enchantmentRecord);
 	replica.put("enchantmentSeed", obj.itemReplicaInfo.enchantmentSeed);
+	replica.put("ascendant1", obj.itemReplicaInfo.ascendant1);
+	replica.put("ascendant2", obj.itemReplicaInfo.ascendant2);
 	root.add_child("replica", replica);
-	// TODO: ascendant changes here, not critical, not used by IAGD
 
 
 	boost::property_tree::ptree stats;

--- a/IAGrim/UI/Misc/CEF/UserFeedback.cs
+++ b/IAGrim/UI/Misc/CEF/UserFeedback.cs
@@ -21,6 +21,7 @@ namespace IAGrim.UI.Misc.CEF {
         public UserFeedback(UserFeedbackLevel level, string message, string url) {
             this.Level = level;
             this.Message = message;
+            this.URL = url;
         }
 
         public static UserFeedback FromTag(string tag) {


### PR DESCRIPTION
This fixes a few minor issues:
* Adds the ascendant information to replica. This fixes the issue that after a clear/import/... and replica item is being parsed by the game, that the ascendant information would be missing from the WebUI after.
* Items grabbed by IA are written to a tmp file, and then moved to the final csv file. This prevents the FileWatcher to read an incomplete file.
* Added missing URL to USerFeedback

Note: I have not tested to compile or run this on Windows. I have only compiled/run this on Linux.