### PR TITLE
Fixed the relative paths in backups

### DIFF
--- a/IAGrim/Utilities/Cloud/FileBackup.cs
+++ b/IAGrim/Utilities/Cloud/FileBackup.cs
@@ -184,12 +184,8 @@ namespace IAGrim.Utilities.Cloud {
                     continue;
                 }
 
-                var relativePath = f.Replace(GlobalPaths.SavePath, "").Replace(Path.GetFileName(f), "");
-
-                if (relativePath.StartsWith("\\")) {
-                    relativePath = relativePath.Substring(1);
-                }
-                zip.CreateEntryFromFile(f, relativePath +"/"+ f);
+                var relativePath = Path.GetRelativePath(GlobalPaths.SavePath, f);
+                zip.CreateEntryFromFile(f, relativePath);
             }
 
             zip.Comment = $"This backup of {character} was created at {DateTime.Now:G}.";
@@ -274,11 +270,8 @@ namespace IAGrim.Utilities.Cloud {
                 }
 
 
-                var relativePath = f.Replace(GlobalPaths.SavePath, "").Replace(Path.GetFileName(f), "");
-                if (relativePath.StartsWith("\\")) {
-                    relativePath = relativePath.Substring(1);
-                }
-                zip.CreateEntryFromFile(f, relativePath + Path.GetFileName(f));
+                var relativePath = Path.GetRelativePath(GlobalPaths.SavePath, f);
+                zip.CreateEntryFromFile(f, relativePath);
             }
 
             Logger.Info("Backing up items..");


### PR DESCRIPTION
The file path in the backups were wrong. I am not sure how `relativePath +"/"+ f` worked, but this change uses the correct relative path for the file inside the backup.

Note: I have not tested to compile or run this on Windows. I have only compiled/run this on Linux. Though this is using the .net api and thus should work the same on Windows.