### PR TITLE
Fix: Allow Gazer Man to be deposit

### DIFF
--- a/Parser/Stash/HardcodedStackableRecords.cs
+++ b/Parser/Stash/HardcodedStackableRecords.cs
@@ -46,7 +46,7 @@ namespace IAGrim.Parser.Stash {
             "records/items/crafting/consumables/potion_vitalityresist01.dbr",
             "records/items/crafting/blueprints/other/craft_potionb103.dbr",
             "records/items/crafting/consumables/potion_bleedresist01.dbr",
-            "records/storyelements/questassets/q000_torso.dbr",
+            // "records/storyelements/questassets/q000_torso.dbr", // Gazer Man
             "records/storyelements/rewards/q003_ring_slithring.dbr",
             "records/items/gearaccessories/necklaces/a00_necklace.dbr", // Salt bag
             //"records/storyelementsgdx2/questassets/areag_n.dbr"


### PR DESCRIPTION
This allows `Gazer Man` to be deposit. It is already whitelisted in `InventorySack_AddItem.cpp`  and `ArzParser.cs` so I suppose it should be allowed. `Miss Gazer Man` is also allowed.