### PR TITLE
Fix: Added missing include for _beginthread

### DIFF
--- a/HookDll/Hook/InventorySack_AddItem.cpp
+++ b/HookDll/Hook/InventorySack_AddItem.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include <stdlib.h>
+#include <process.h>
 #include "MessageType.h"
 #include <detours.h>
 #include "InventorySack_AddItem.h"

--- a/HookDll/Hook/OnDemandSeedInfo.cpp
+++ b/HookDll/Hook/OnDemandSeedInfo.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include <stdio.h>
+#include <process.h>
 #include <random>
 #include <stdlib.h>
 #include "MessageType.h"

--- a/HookDll/Hook/dllmain.cpp
+++ b/HookDll/Hook/dllmain.cpp
@@ -2,6 +2,7 @@
 #include <chrono>
 #include <codecvt> // wstring_convert
 #include <windows.h>
+#include <process.h>
 #include <stdlib.h>
 #include <objbase.h>
 #include <fstream>


### PR DESCRIPTION
_beginthread requires `process.h` as include:
https://learn.microsoft.com/de-de/cpp/c-runtime-library/reference/beginthread-beginthreadex?view=msvc-170